### PR TITLE
Ubuntu 22.04.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the USB can be modified under Linux. Example command:
 
 ### Ubuntu
 
-`ubuntu/create_image.sh` script automatically downloads Ubuntu release 22.04.2,
+`ubuntu/create_image.sh` script automatically downloads Ubuntu release 22.04.4,
 extracts it, injects preseeds and packages the new iso image. General preseed
 configuration can be found in the `ubuntu/main.cfg` file, if necessary, it can
 be edited. The script also takes arguments if the original Ubuntu iso image has
@@ -66,11 +66,11 @@ directory:
 
 Extracts downloaded image and saves modified image (it is important that the
 image is downloaded from
-[here](https://ubuntu.task.gda.pl/ubuntu-releases/22.04.3/ubuntu-22.04.3-desktop-amd64.iso),
+[here](https://ubuntu.task.gda.pl/ubuntu-releases/22.04.4/ubuntu-22.04.4-desktop-amd64.iso),
 otherwise it may work incorrectly):
 
 ```bash
-./ubuntu/create_image.sh -i ~/Downloads/ubuntu-22.04.3-desktop-amd64.iso
+./ubuntu/create_image.sh -i ~/Downloads/ubuntu-22.04.4-desktop-amd64.iso
 ```
 
 Saves modified image as `ubuntu.iso`:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ partitions! If you want custom partitioning run the program with `-p` argument.
 
 #### Exemplary usages
 
-Does everything and saves the image as `ubuntu-auto.iso` in the script execution
-directory:
+Does everything and saves the image as `ubuntu-auto-22.04.4.iso` in the script
+execution directory:
 
 ```bash
 ./ubuntu/create_image.sh

--- a/README.md
+++ b/README.md
@@ -55,25 +55,31 @@ already been downloaded or extracted.
 **Warning!** This script by default wipes the first disks and setups ubuntu
 partitions! If you want custom partitioning run the program with `-p` argument.
 
-#### Exemplary usages:
+#### Exemplary usages
+
 Does everything and saves the image as `ubuntu-auto.iso` in the script execution
 directory:
+
 ```bash
 ./ubuntu/create_image.sh
 ```
+
 Extracts downloaded image and saves modified image (it is important that the
-image is
-[22.04.2](https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.2-desktop-amd64.iso),
+image is downloaded from
+[here](https://ubuntu.task.gda.pl/ubuntu-releases/22.04.3/ubuntu-22.04.3-desktop-amd64.iso),
 otherwise it may work incorrectly):
+
 ```bash
-./ubuntu/create_image.sh -i ~/Downloads/ubuntu-22.04.2-desktop-amd64.iso
+./ubuntu/create_image.sh -i ~/Downloads/ubuntu-22.04.3-desktop-amd64.iso
 ```
+
 Saves modified image as `ubuntu.iso`:
 ```bash
 ./ubuntu/create_image.sh -o ubuntu.iso
 ```
 
-Thre is a help if needed:
+There is a help if needed:
+
 ```bash
 ./ubuntu/create_image.sh -h
 ```
@@ -87,7 +93,7 @@ Debian preseeds are located in the `debian/` directory.
 Boot the Debian ISO and append the following to the kernel commandline before
 launching the installer:
 
-```
+```bash
 auto url=http://[your ip]:8080/debian/preseed.cfg
 ```
 
@@ -95,7 +101,7 @@ auto url=http://[your ip]:8080/debian/preseed.cfg
 
 Add the following snippet to your netboot.xyz Debian netboot entry:
 
-```
+```bash
 set preseedurl http://[your ip]:8080/debian/preseed.cfg
 preseed/url=${preseedurl}
 ```

--- a/ubuntu/create_image.sh
+++ b/ubuntu/create_image.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 
 UBUNTU_VERSION="22.04.3"
 ISO_DOWNLOAD_LINK="https://ubuntu.task.gda.pl/ubuntu-releases/${UBUNTU_VERSION}/ubuntu-${UBUNTU_VERSION}-desktop-amd64.iso"
-PARTITIONING_PRESEED="partitioning.cfg"
-MAIN_PRESEED="main.cfg"
+SCRIPTDIR=$(readlink -f $(dirname "$0"))
+PARTITIONING_PRESEED="$SCRIPTDIR/partitioning.cfg"
+MAIN_PRESEED="$SCRIPTDIR/main.cfg"
 OUTPUT_ISO="ubuntu-auto-${UBUNTU_VERSION}.iso"
 ISO_PATH=""
 ISO_EXTR_PATH=""

--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -43,8 +43,16 @@ ubiquity ubiquity/success_command string \
   in-target apt --fix-broken install;\
   in-target apt upgrade;\
   in-target apt remove -y gnome-initial-setup;\
-  in-target apt install -y open-vm-tools
-  in-target apt install -y openssh-server
+  in-target apt install -y open-vm-tools;\
+  in-target apt install -y openssh-server;\
+  in-target systemctl start ssh && systemctl enable ssh;\
+  in-target sed -i 's/^[[:space:]#]*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config;\
+  in-target systemctl reload ssh;\
+  in-target apt install -y dbus-x11;\
+  in-target gsettings set org.gnome.SessionManager logout-prompt false;\
+  in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub
+  in-target echo "GRUB_TIMEOUT=5" >> /etc/default/grub
+  in-target update-grub
 
 # Poweroff after install
 # ubiquity ubiquity/poweroff boolean true

--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -51,6 +51,7 @@ ubiquity ubiquity/success_command string \
   in-target systemctl enable --now ssh;\
   in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub;\
   in-target sed -i 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub;\
+  in-target sed -i 's/kernel.printk.*/kernel.printk = 1 4 1 7/' /etc/sysctl.d/10-console-messages.conf;\
   in-target update-grub;\
   in-target gsettings set org.gnome.SessionManager logout-prompt false;\
 

--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -52,6 +52,8 @@ ubiquity ubiquity/success_command string \
   in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub;\
   in-target sed -i 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub;\
   in-target sed -i 's/kernel.printk.*/kernel.printk = 1 4 1 7/' /etc/sysctl.d/10-console-messages.conf;\
+  in-target sed -i 's/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/' /etc/default/grub;\
+  in-target sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL="serial gfxterm"/' /etc/default/grub;\
   mount --bind /proc /target/proc;\
   mount --bind /sys /target/sys;\
   mount --bind /dev /target/dev;\

--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -52,6 +52,9 @@ ubiquity ubiquity/success_command string \
   in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub;\
   in-target sed -i 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub;\
   in-target sed -i 's/kernel.printk.*/kernel.printk = 1 4 1 7/' /etc/sysctl.d/10-console-messages.conf;\
+  mount --bind /proc /target/proc;\
+  mount --bind /sys /target/sys;\
+  mount --bind /dev /target/dev;\
   in-target update-grub;\
   in-target gsettings set org.gnome.SessionManager logout-prompt false;\
 

--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -45,14 +45,14 @@ ubiquity ubiquity/success_command string \
   in-target apt remove -y gnome-initial-setup;\
   in-target apt install -y open-vm-tools;\
   in-target apt install -y openssh-server;\
-  in-target systemctl start ssh && systemctl enable ssh;\
-  in-target sed -i 's/^[[:space:]#]*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config;\
-  in-target systemctl reload ssh;\
+  in-target apt install -y libglib2.0-bin;\
   in-target apt install -y dbus-x11;\
-  in-target gsettings set org.gnome.SessionManager logout-prompt false;\
+  in-target sed -i 's/^[[:space:]#]*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config;\
+  in-target systemctl enable --now ssh;\
   in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub;\
   in-target sed -i 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub;\
   in-target update-grub;\
+  in-target gsettings set org.gnome.SessionManager logout-prompt false;\
 
 # Poweroff after install
 # ubiquity ubiquity/poweroff boolean true

--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -50,9 +50,9 @@ ubiquity ubiquity/success_command string \
   in-target systemctl reload ssh;\
   in-target apt install -y dbus-x11;\
   in-target gsettings set org.gnome.SessionManager logout-prompt false;\
-  in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub
-  in-target echo "GRUB_TIMEOUT=5" >> /etc/default/grub
-  in-target update-grub
+  in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub;\
+  in-target sed -i 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub;\
+  in-target update-grub;\
 
 # Poweroff after install
 # ubiquity ubiquity/poweroff boolean true


### PR DESCRIPTION
This is supposed to fix: https://github.com/Dasharo/preseeds/issues/6

Additionally, support for 22.04.03 was added, as previous script had some assumptions about the layout of the previous ISO version.

I'm testing in QEMU right now and will report here with the results.

The ISO was created with:

```
./create_image.sh -i ~/Downloads/ubuntu-22.04.3-desktop-amd64.iso -p
```

We will need to test it on some hardware (such as MSI) as well.