### PR TITLE
ubuntu/main.cfg: Lower printk level

### DIFF
--- a/ubuntu/main.cfg
+++ b/ubuntu/main.cfg
@@ -51,7 +51,7 @@ ubiquity ubiquity/success_command string \
   in-target systemctl enable --now ssh;\
   in-target sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 console=tty0 console=ttyS0,115200"/' /etc/default/grub;\
   in-target sed -i 's/GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub;\
-  in-target sed -i 's/kernel.printk.*/kernel.printk = 1 4 1 7/' /etc/sysctl.d/10-console-messages.conf;\
+  in-target sed -i 's/kernel.printk.*/kernel.printk = 0 4 1 7/' /etc/sysctl.d/10-console-messages.conf;\
   in-target sed -i 's/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/' /etc/default/grub;\
   in-target sed -i 's/^GRUB_TERMINAL=.*/GRUB_TERMINAL="serial gfxterm"/' /etc/default/grub;\
   mount --bind /proc /target/proc;\


### PR DESCRIPTION
To ensure kernel messages won't interfere during automatic tests the printk level needs to be lowered 