### PR TITLE
ubuntu/create_image.sh: Bump LTS version to newest available

### DIFF
--- a/ubuntu/create_image.sh
+++ b/ubuntu/create_image.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-UBUNTU_VERSION="22.04.4"
+UBUNTU_VERSION="24.04.2"
 ISO_DOWNLOAD_LINK="https://ubuntu.task.gda.pl/ubuntu-releases/${UBUNTU_VERSION}/ubuntu-${UBUNTU_VERSION}-desktop-amd64.iso"
 SCRIPTDIR=$(readlink -f $(dirname "$0"))
 PARTITIONING_PRESEED="$SCRIPTDIR/partitioning.cfg"


### PR DESCRIPTION
Last version from task.gda.pl seems to fail on download, this one managed to download without issues