### PR TITLE
fedora/ks.cfg: Add changing the hostname

### DIFF
--- a/fedora/ks.cfg
+++ b/fedora/ks.cfg
@@ -34,6 +34,9 @@ btrfs / --subvol --name=root LABEL=fedora
 sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 systemctl enable sshd
 
+# Change the hostname
+hostnamectl set-hostname --static 3mdeb
+
 # Tweak GRUB config
 sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=5/' /etc/default/grub
 sed -i 's/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/' /etc/default/grub


### PR DESCRIPTION
It was missing and so OSFV couldn't log in to fedora immediately after installation without manually changing the hostname