### PR TITLE
Fedora ks tweaks

### DIFF
--- a/fedora/ks.cfg
+++ b/fedora/ks.cfg
@@ -18,7 +18,7 @@ user --name=linux --groups=wheel --password=$6$FY/YSTovPfAOkdg/$o0dGMNyW9Squf/VW
 reqpart
 
 # root partition with 20GB
-part btrfs.236 --fstype="btrfs" --size=20480 --maxsize=20480
+part btrfs.236 --fstype="btrfs" --size=30960 --maxsize=30960
 btrfs none --label=fedora btrfs.236
 btrfs / --subvol --name=root LABEL=fedora
 


### PR DESCRIPTION
a) 50GiB is too much. A fresh install uses ~12GB leaving ~8GB free with a 20GB disk.
b) using `--static` only changed the static hostname which is not displayed in the command prompt. Dropping this option changes both `static` and `transient` and should fix the issue with wrong hosname