### PR TITLE
fedora/ks.cfg: Enable gnome autologin

### DIFF
--- a/fedora/ks.cfg
+++ b/fedora/ks.cfg
@@ -59,6 +59,10 @@ sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
 # Disable Gnome logout prompt (if GNOME is installed)
 gsettings set org.gnome.SessionManager logout-prompt false || true
 
+# Enable autologin to make sure everything is initialized when connecting via SSH/serial
+# Appends two lines to the [daemon] section of gdm/custom.conf
+gawk -i inplace '{if ($0=="[daemon]") {print "[daemon]"; print "AutomaticLoginEnable=True"; print "AutomaticLogin=linux"} else print}' /etc/gdm/custom.conf
+
 %end
 
 reboot


### PR DESCRIPTION
Some things might not be initialized if noone has logged in in the graphical prompt. This includes pactl sinks not being initialized.

This change will help with automatic tests, the known example being AUD tests which will sometimes fail to detect devices using pactl if no user is logged in the graphical login prompt